### PR TITLE
Add Komodo IDE and Komodo Edit to supported applications

### DIFF
--- a/passwordexporter/install.rdf
+++ b/passwordexporter/install.rdf
@@ -81,8 +81,8 @@
         <em:targetApplication>
             <Description>
                 <em:id>{36E66FA0-F259-11D9-850E-000D935D3368}</em:id>
-                <em:minVersion>4.2</em:minVersion>
-                <em:maxVersion>4.*</em:maxVersion>
+                <em:minVersion>4.0</em:minVersion>
+                <em:maxVersion>6.*</em:maxVersion>
             </Description>
         </em:targetApplication>
     
@@ -91,7 +91,7 @@
             <Description>
                 <em:id>{b1042fb5-9e9c-11db-b107-000d935d3368}</em:id>
                 <em:minVersion>4.0</em:minVersion>
-                <em:maxVersion>4.*</em:maxVersion>
+                <em:maxVersion>6.*</em:maxVersion>
             </Description>
         </em:targetApplication>
     </Description>


### PR DESCRIPTION
Hello **fligtar**,

Thanks for your great work!  There was no existing password export feature or extension for Komodo, so I added the application targets for Komodo IDE and Komodo Edit/OpenKomodo.  I have tested it with Komodo Edit 6.0 on Linux, but it should work with all Komodos with versions 4+, that is when Komodo started to use the Mozilla Password Manager.

_Known bugs:_
- There is no 'security' tab in Komodo preferences, the Password Exporter is only accessible through **Tools -> Addons**
- The Password Exporter dialog box is missing the background
- Export to CSV does not seem to work

I would attempt to provide bugfixes but I have almost no experience with Mozilla extensions.  Though buggy on Komodo, this extension was really helpful for me, so I hope my addition can help others!

Cheers,

Charles
